### PR TITLE
Investigate google redirect issue

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,30 +7,6 @@
         <priority>1.0</priority>
     </url>
     <url>
-        <loc>https://mybounceplace.com/#bounce-houses</loc>
-        <lastmod>2024-12-26</lastmod>
-        <changefreq>weekly</changefreq>
-        <priority>0.9</priority>
-    </url>
-    <url>
-        <loc>https://mybounceplace.com/#about</loc>
-        <lastmod>2024-12-26</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.7</priority>
-    </url>
-    <url>
-        <loc>https://mybounceplace.com/#contact</loc>
-        <lastmod>2024-12-26</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.8</priority>
-    </url>
-    <url>
-        <loc>https://mybounceplace.com/#faq</loc>
-        <lastmod>2024-12-26</lastmod>
-        <changefreq>monthly</changefreq>
-        <priority>0.6</priority>
-    </url>
-    <url>
         <loc>https://mybounceplace.com/blog.html</loc>
         <lastmod>2024-12-26</lastmod>
         <changefreq>weekly</changefreq>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove hash fragment URLs from `sitemap.xml` to resolve Google's redirect and duplicate content warnings.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Google's crawler interprets URLs with hash fragments (e.g., `example.com/#section`) as pointing to the base page (`example.com`). Including multiple such URLs in the sitemap leads to the crawler seeing duplicate content or unexpected redirects, as all hash-fragmented URLs resolve to the same server-side resource. Removing them ensures the sitemap only lists unique, crawlable pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-8eb529a7-05a0-4c1b-8ceb-0fc0ffb1a6d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8eb529a7-05a0-4c1b-8ceb-0fc0ffb1a6d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>